### PR TITLE
Added build-win script, module exported correctly

### DIFF
--- a/ApiCalendar.js
+++ b/ApiCalendar.js
@@ -1,5 +1,4 @@
 const Config = require("../../apiGoogleconfig.json");
-
 class ApiCalendar {
     constructor() {
         this.sign = false;

--- a/ApiCalendar.js
+++ b/ApiCalendar.js
@@ -175,11 +175,5 @@ class ApiCalendar {
         });
     }
 }
-let apiCalendar;
-try {
-    apiCalendar = new ApiCalendar();
-}
-catch (e) {
-    console.log(e);
-}
+let apiCalendar = new ApiCalendar();
 export default apiCalendar;

--- a/ApiCalendar.ts
+++ b/ApiCalendar.ts
@@ -185,10 +185,5 @@ class ApiCalendar {
     }
 }
 
-let apiCalendar;
-try {
-    apiCalendar = new ApiCalendar();
-} catch (e) {
-    console.log(e);
-}
+let apiCalendar = new ApiCalendar();
 export default apiCalendar;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./build/ApiCalendar.js",
   "scripts": {
     "build": "tslint --project . && tsc && rm *.test.js",
+    "build-win": "tslint --project . && tsc && del *.test.js",
     "test": "jest",
     "babel": "babel ./ApiCalendar.js -d build"
   },


### PR DESCRIPTION
- rm isn't present on windows, added build-win script with "del"
- constructor already has a try catch that puts the error on console, no need for that on module export, which also fails tsc, thinking the exported thing is "any" type.