### PR TITLE
more easier definition

### DIFF
--- a/ApiCalendar.js
+++ b/ApiCalendar.js
@@ -8,7 +8,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 //@ts-ignore 
 import Config from "../../apiGoogleconfig.json";
-export class GoogleCalendarApi {
+class GoogleCalendarApi {
     constructor() {
         this.sign = false;
         this.gapi = null;
@@ -212,3 +212,5 @@ export class GoogleCalendarApi {
         });
     }
 }
+const googleApiService = GoogleCalendarApi.getInstance();
+export default googleApiService;

--- a/ApiCalendar.ts
+++ b/ApiCalendar.ts
@@ -3,7 +3,7 @@ import Config from "../../apiGoogleconfig.json";
 
 declare var window: any;
 
-export class GoogleCalendarApi {
+class GoogleCalendarApi {
     private static instance: GoogleCalendarApi;
     sign: boolean = false;
     gapi: any = null;
@@ -223,3 +223,6 @@ export class GoogleCalendarApi {
         return result;
     }
 }
+
+const googleApiService = GoogleCalendarApi.getInstance();
+export default googleApiService;

--- a/build/ApiCalendar.js
+++ b/build/ApiCalendar.js
@@ -3,7 +3,6 @@
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-exports.GoogleCalendarApi = undefined;
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -41,7 +40,7 @@ var __awaiter = undefined && undefined.__awaiter || function (thisArg, _argument
 };
 //@ts-ignore 
 
-var GoogleCalendarApi = exports.GoogleCalendarApi = function () {
+var GoogleCalendarApi = function () {
     function GoogleCalendarApi() {
         _classCallCheck(this, GoogleCalendarApi);
 
@@ -331,3 +330,6 @@ var GoogleCalendarApi = exports.GoogleCalendarApi = function () {
 
     return GoogleCalendarApi;
 }();
+
+var googleApiService = GoogleCalendarApi.getInstance();
+exports.default = googleApiService;


### PR DESCRIPTION
To easen to usage everytime from this:

`let api = GoogleApiCalendar.getInstance();`

to just

`googleApiService.`